### PR TITLE
Add manager account to rococo issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rococo.yaml
+++ b/.github/ISSUE_TEMPLATE/rococo.yaml
@@ -38,6 +38,14 @@ body:
       placeholder: "Example: 3000"
     validations:
       required: true
+  - type: input
+    id: manager-account
+    attributes:
+      label: Parachain Manager Account
+      description: "A Rococo account that would be set as the manager for this parachain. You might have already set one if you have registered the parachain on your own, please use the same account when filling this field."
+      placeholder: "Example:5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    validations:
+      required: true
   - type: dropdown
     id: para-id-term
     attributes:


### PR DESCRIPTION
Adding a manager account in the template that teams will need to fill.
If the registered manager account is controlled by the parachain team, parachains will easily be managed by the teams themselves as we could unlock these.