### PR TITLE
Check next ParaID and reserve it if needed

### DIFF
--- a/cli/src/calls.rs
+++ b/cli/src/calls.rs
@@ -33,6 +33,22 @@ pub fn create_batch_all_call(calls: Vec<Call>) -> Result<Call, Box<dyn std::erro
 }
 
 //
+// Reserve the next para_id available in Rococo
+//
+pub async fn reserve(api: OnlineClient<PolkadotConfig>) -> Result<(), subxt::Error> {
+    let root = get_signer();
+
+    let tx = rococo::tx().registrar().reserve();
+
+    api.tx()
+        .sign_and_submit_then_watch_default(&tx, &root)
+        .await?
+        .wait_for_finalized_success()
+        .await?;
+    Ok(())
+}
+
+//
 // Fund the parachain manager from the faucet address using sudo
 //
 pub fn create_force_transfer_call(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,12 +4,12 @@ use para_onboarding::{
     calls::{
         create_batch_all_call, create_force_register_call, create_force_transfer_call,
         create_scheduled_assign_slots_call, create_scheduled_remove_lock_call, create_sudo_call,
-        sign_and_send_proxy_call, reserve, Call,
+        reserve, sign_and_send_proxy_call, Call,
     },
     chain_connector::{kusama_connection, polkadot_connection, rococo_connection},
     utils::{
-        calculate_sovereign_account, get_file_content, has_slot_in_rococo, is_registered,
-        needs_perm_slot, parse_validation_code, get_next_free_para
+        calculate_sovereign_account, get_file_content, get_next_free_para, has_slot_in_rococo,
+        is_registered, needs_perm_slot, parse_validation_code,
     },
 };
 use sp_core::sr25519::Pair;
@@ -60,8 +60,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .unwrap_or(false);
 
-    // If needs a permanent slot, check if the paraId has been reserved and if not, reserve it in Rococo 
-    // 
+    // If needs a permanent slot, check if the paraId has been reserved and if not, reserve it in Rococo
+    //
     // If paraId < nextParaId needs means is reserved,
     // If paraId = nextParaId needs to be reserved
     // If paraId > nextParaId throws an Error, because teh para_id indicated should be the nextParaId
@@ -69,13 +69,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("ParaId: {} needs a temporary slot", para_id.clone());
         let next_para_id = get_next_free_para(rococo_api.clone()).await?;
         if next_para_id == para_id.clone() {
-            if let Err(subxt::Error::Runtime(dispatch_err)) =
-            reserve(rococo_api.clone()).await
-            {
-                eprintln!("Could not dispatch the call to reserve the para_id: {}", dispatch_err);
+            if let Err(subxt::Error::Runtime(dispatch_err)) = reserve(rococo_api.clone()).await {
+                eprintln!(
+                    "Could not dispatch the call to reserve the para_id: {}",
+                    dispatch_err
+                );
             }
-        }
-        else if  next_para_id < para_id {
+        } else if next_para_id < para_id {
             println!(
                 "Error: ParaId: {} is not reserved and is not the next free para id",
                 args.para_id.clone()

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -39,11 +39,17 @@ pub async fn maybe_leases(
 //
 // Check the next free para available in in Rococo
 //
-pub async fn next_free_para(
-    api: OnlineClient<PolkadotConfig>,
-) -> u32 {
+pub async fn next_free_para(api: OnlineClient<PolkadotConfig>) -> u32 {
     let query = rococo::storage().registrar().next_free_para_id();
-    let id = api.storage().at_latest().await.expect("Error getting the next free para id").fetch(&query).await.unwrap().expect("Error getting the next free para id");
+    let id = api
+        .storage()
+        .at_latest()
+        .await
+        .expect("Error getting the next free para id")
+        .fetch(&query)
+        .await
+        .unwrap()
+        .expect("Error getting the next free para id");
     id.0
 }
 

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -37,7 +37,18 @@ pub async fn maybe_leases(
 }
 
 //
-// Checks if paraId is already registered
+// Check the next free para available in in Rococo
+//
+pub async fn next_free_para(
+    api: OnlineClient<PolkadotConfig>,
+) -> u32 {
+    let query = rococo::storage().registrar().next_free_para_id();
+    let id = api.storage().at_latest().await.expect("Error getting the next free para id").fetch(&query).await.unwrap().expect("Error getting the next free para id");
+    id.0
+}
+
+//
+// Checks if paraId is already registered in Rococo
 //
 pub async fn paras_registered(
     api: OnlineClient<PolkadotConfig>,

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use subxt::{utils::AccountId32, OnlineClient, PolkadotConfig};
 use subxt_signer::{bip39::Mnemonic, sr25519::Keypair};
 
-use crate::query::{maybe_leases, paras_registered};
+use crate::query::{maybe_leases, paras_registered, next_free_para};
 
 // Rococo types
 #[subxt::subxt(runtime_metadata_path = "metadata/local_metadata.scale")]
@@ -102,6 +102,13 @@ pub async fn has_slot_in_rococo(
     } else {
         Ok(false)
     }
+}
+
+// Check if the next free para available in in Rococo is grater than ours
+pub async fn get_next_free_para(
+    rococo_api: OnlineClient<PolkadotConfig>,
+) -> Result<u32, Box<dyn std::error::Error>> {
+    Ok(next_free_para(rococo_api).await)
 }
 
 // Check if the parachain is registerd  in Rococo

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use subxt::{utils::AccountId32, OnlineClient, PolkadotConfig};
 use subxt_signer::{bip39::Mnemonic, sr25519::Keypair};
 
-use crate::query::{maybe_leases, paras_registered, next_free_para};
+use crate::query::{maybe_leases, next_free_para, paras_registered};
 
 // Rococo types
 #[subxt::subxt(runtime_metadata_path = "metadata/local_metadata.scale")]


### PR DESCRIPTION
Fix for the Issue https://github.com/paritytech/subport/issues/586

Check the next paraId in the pallet `registrar` and compare it with the `para_id` to be onboarded:
- If paraId = nextParaId means it needs to be reserved -> call the extrinsic `reserve`()
- If paraId > nextParaId throws an Error, because teh para_id indicated should be the nextParaId
- If paraId < nextParaId needs means is reserved, don't do anything